### PR TITLE
Add the ability to set state / attributes with entity proxies

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@digital-alchemy/hass",
   "repository": "https://github.com/Digital-Alchemy-TS/hass",
   "homepage": "https://docs.digital-alchemy.app/Hass",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "scripts": {
     "build": "rm -rf dist/; tsc",
     "lint": "eslint src",


### PR DESCRIPTION
Entity proxies will now emit state & attribute updates if assigned to. These happen via the rest api, and are not sync

```typescript
function Example({ hass }: TServiceParams) {
  const entity = hass.entity.byId("binary_sensor.foo");
  async function MyWorkflow() {
    entity.state = "off";
    // wait for hass to confirm if that matters
    await entity.nextState();
    await sleep(1000);
    entity.state = "on";
  }
}
```