### PR TITLE
onUpdate hooks can be removed

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@digital-alchemy/hass",
   "repository": "https://github.com/Digital-Alchemy-TS/hass",
   "homepage": "https://docs.digital-alchemy.app/Hass",
-  "version": "0.3.17",
+  "version": "0.3.18",
   "scripts": {
     "build": "rm -rf dist/; tsc",
     "lint": "eslint src",


### PR DESCRIPTION
#### Changes

Changes the return type of `onUpdate` from void to an object with a removal function for the update hook

Add a new property to entity proxies that is capable of removing all update listeners for that entity

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme and [docs](https://docs.digital-alchemy.app/) (updated or not needed)
- [x] Tests (added, updated or not needed)
