### PR TITLE
Tweaks to unit testing flows

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@digital-alchemy/hass",
   "repository": "https://github.com/Digital-Alchemy-TS/hass",
   "homepage": "https://docs.digital-alchemy.app/Hass",
-  "version": "0.3.22",
+  "version": "0.3.23",
   "scripts": {
     "build": "rm -rf dist/; tsc",
     "lint": "eslint src",

--- a/src/e2e/utils.ts
+++ b/src/e2e/utils.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @cspell/spellchecker */
 export const BASE_URL = "http://localhost:9123";
 export const TOKEN =
   "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJhYTdjOGQ5MzBiMDM0MDM2OGVjZTdjOTRjMTcyOWQ0OSIsImlhdCI6MTcxNDYwMzkyMywiZXhwIjoyMDI5OTYzOTIzfQ.Tvoh25bukQh5T5WIuvvkL9jVBihcOGG6D5JYdqdwx1U";

--- a/src/mock_assistant/extensions/events.extension.ts
+++ b/src/mock_assistant/extensions/events.extension.ts
@@ -1,6 +1,8 @@
-import { TServiceParams } from "@digital-alchemy/core";
+import { sleep, TServiceParams } from "@digital-alchemy/core";
 
 import { ENTITY_STATE, EntityUpdateEvent, PICK_ENTITY } from "../../helpers";
+
+const SUPER_SHORT = 1;
 
 export function Events({ mock_assistant, hass }: TServiceParams) {
   let id = 1000;
@@ -24,6 +26,8 @@ export function Events({ mock_assistant, hass }: TServiceParams) {
     const old_state = mock_assistant.fixtures.byId(entity);
     new_state = mock_assistant.fixtures.replace(entity, new_state);
     await emitEvent("state_changed", { new_state, old_state });
+    // help ensure all the async flows settle
+    await sleep(SUPER_SHORT);
   }
 
   return {

--- a/src/mock_assistant/extensions/fixtures.extension.ts
+++ b/src/mock_assistant/extensions/fixtures.extension.ts
@@ -1,6 +1,7 @@
 import {
   BootstrapException,
   InternalError,
+  is,
   TServiceParams,
 } from "@digital-alchemy/core";
 import { existsSync, readFileSync } from "fs";
@@ -18,6 +19,7 @@ export function Fixtures({
   hass,
   lifecycle,
   config,
+  internal,
   context,
   mock_assistant,
 }: TServiceParams) {
@@ -29,9 +31,11 @@ export function Fixtures({
     mock_assistant.fixtures.data?.entities ?? [];
   hass.fetch.listServices = async () =>
     mock_assistant.fixtures.data?.services ?? [];
+  hass.fetch.getConfig = async () => mock_assistant.fixtures.data?.config;
 
   lifecycle.onPreInit(() => {
     const { MOCK_SOCKET } = config.hass;
+
     const { FIXTURES_FILE } = config.mock_assistant;
     if (!MOCK_SOCKET) {
       // There needs to be a shared understanding that nobody is actually sending message traffic anywhere
@@ -48,6 +52,10 @@ export function Fixtures({
         "MISSING_FIXTURES_FILE",
         `${FIXTURES_FILE} does not exist`,
       );
+    }
+    if (is.empty(config.hass.TOKEN)) {
+      // prevents throwing errors
+      internal.boilerplate.configuration.set("hass", "TOKEN", "--");
     }
 
     mock_assistant.fixtures.data = JSON.parse(

--- a/src/mock_assistant/helpers/fixtures.ts
+++ b/src/mock_assistant/helpers/fixtures.ts
@@ -4,6 +4,7 @@ import {
   ENTITY_STATE,
   EntityRegistryItem,
   FloorDetails,
+  HassConfig,
   HassServiceDTO as HassServiceDefinition,
   LabelDefinition,
   PICK_ENTITY,
@@ -11,10 +12,11 @@ import {
 
 export type ScannerCacheData = {
   areas: AreaDetails[];
-  services: HassServiceDefinition[];
-  labels: LabelDefinition[];
-  floors: FloorDetails[];
+  config: HassConfig;
   devices: DeviceDetails[];
   entities: ENTITY_STATE<PICK_ENTITY>[];
   entity_registry: EntityRegistryItem<PICK_ENTITY>[];
+  floors: FloorDetails[];
+  labels: LabelDefinition[];
+  services: HassServiceDefinition[];
 };

--- a/src/mock_assistant/main.ts
+++ b/src/mock_assistant/main.ts
@@ -25,6 +25,7 @@ const writeFixtures = CreateApplication({
           JSON.stringify(
             {
               areas: hass.area.current,
+              config: await hass.fetch.getConfig(),
               devices: hass.device.current,
               entities: hass.entity.listEntities().map(i => hass.entity.raw(i)),
               entity_registry: hass.entity.registry.current,

--- a/src/testing/workflow.spec.ts
+++ b/src/testing/workflow.spec.ts
@@ -8,7 +8,7 @@ import {
 import dayjs from "dayjs";
 
 import { LIB_HASS } from "..";
-import { LIB_MOCK_ASSISTANT } from "../mock_assistant";
+import { CreateTestRunner, LIB_MOCK_ASSISTANT } from "../mock_assistant";
 
 describe("Workflows", () => {
   const application = CreateApplication({
@@ -45,6 +45,8 @@ describe("Workflows", () => {
     },
   });
 
+  const runner = CreateTestRunner(application);
+
   afterEach(async () => {
     await application.teardown();
     jest.restoreAllMocks();
@@ -53,90 +55,62 @@ describe("Workflows", () => {
   describe("Event and Response", () => {
     it("should be able to trigger a workflow", async () => {
       expect.assertions(2);
-      await application.bootstrap({
-        appendLibrary: LIB_MOCK_ASSISTANT,
-        appendService: {
-          Runner({ mock_assistant, lifecycle, hass }: TServiceParams) {
-            lifecycle.onReady(async () => {
-              const turnOn = jest.spyOn(hass.call.switch, "turn_on");
-              const turnOff = jest.spyOn(hass.call.switch, "turn_off");
-              await mock_assistant.events.emitEntityUpdate("sensor.magic", {
-                state: "test",
-              });
-              await sleep(1);
-              await mock_assistant.events.emitEntityUpdate("sensor.magic", {
-                state: "foo",
-              });
-              expect(turnOn).toHaveBeenCalledTimes(1);
-              expect(turnOff).toHaveBeenCalledTimes(1);
-            });
-          },
-        },
-        configuration: {
-          boilerplate: { LOG_LEVEL: "error" },
-          hass: { MOCK_SOCKET: true, TOKEN: "--" },
-        },
+      await runner(undefined, async ({ mock_assistant, hass }) => {
+        const turnOn = jest.spyOn(hass.call.switch, "turn_on");
+        const turnOff = jest.spyOn(hass.call.switch, "turn_off");
+        await mock_assistant.events.emitEntityUpdate("sensor.magic", {
+          state: "test",
+        });
+        await mock_assistant.events.emitEntityUpdate("sensor.magic", {
+          state: "foo",
+        });
+        expect(turnOn).toHaveBeenCalledTimes(1);
+        expect(turnOff).toHaveBeenCalledTimes(1);
       });
     });
 
     it("should be able to trigger a from an initial state", async () => {
       expect.assertions(1);
-      await application.bootstrap({
-        appendLibrary: LIB_MOCK_ASSISTANT,
-        appendService: {
-          Runner({ mock_assistant, lifecycle, hass }: TServiceParams) {
-            mock_assistant.fixtures.setState({
-              "sensor.magic": {
-                state: "away",
-              },
-            });
-            lifecycle.onReady(async () => {
-              const turnOn = jest.spyOn(hass.call.switch, "turn_on");
-              await mock_assistant.events.emitEntityUpdate("sensor.magic", {
-                state: "here",
-              });
-              await sleep(1);
-              expect(turnOn).toHaveBeenCalledWith({
-                entity_id: "switch.living_room_mood_lights",
-              });
-            });
-          },
+      await runner(
+        ({ mock_assistant }) => {
+          mock_assistant.fixtures.setState({
+            "sensor.magic": {
+              state: "away",
+            },
+          });
         },
-        configuration: {
-          boilerplate: { LOG_LEVEL: "error" },
-          hass: { MOCK_SOCKET: true, TOKEN: "--" },
+        async ({ hass, mock_assistant }) => {
+          const turnOn = jest.spyOn(hass.call.switch, "turn_on");
+          await mock_assistant.events.emitEntityUpdate("sensor.magic", {
+            state: "here",
+          });
+          await sleep(1);
+          expect(turnOn).toHaveBeenCalledWith({
+            entity_id: "switch.living_room_mood_lights",
+          });
         },
-      });
+      );
     });
 
     it("should not trigger a from an invalid initial state", async () => {
       expect.assertions(1);
-      await application.bootstrap({
-        appendLibrary: LIB_MOCK_ASSISTANT,
-        appendService: {
-          Runner({ mock_assistant, lifecycle, hass }: TServiceParams) {
-            mock_assistant.fixtures.setState({
-              "sensor.magic": {
-                state: "mars",
-              },
-            });
-            lifecycle.onReady(async () => {
-              const turnOn = jest.spyOn(hass.call.switch, "turn_on");
-              await mock_assistant.events.emitEntityUpdate("sensor.magic", {
-                state: "here",
-              });
-              await sleep(1);
-              expect(turnOn).not.toHaveBeenCalledWith({
-                entity_id: "switch.living_room_mood_lights",
-              });
-            });
-          },
+      await runner(
+        ({ mock_assistant }) =>
+          mock_assistant.fixtures.setState({
+            "sensor.magic": {
+              state: "mars",
+            },
+          }),
+        async ({ hass, mock_assistant }) => {
+          const turnOn = jest.spyOn(hass.call.switch, "turn_on");
+          await mock_assistant.events.emitEntityUpdate("sensor.magic", {
+            state: "here",
+          });
+          expect(turnOn).not.toHaveBeenCalledWith({
+            entity_id: "switch.living_room_mood_lights",
+          });
         },
-        configuration: {
-          boilerplate: { LOG_LEVEL: "error" },
-          hass: { MOCK_SOCKET: true, TOKEN: "--" },
-        },
-      });
+      );
     });
   });
 
@@ -151,27 +125,19 @@ describe("Workflows", () => {
 
     it("should run at 3PM", async () => {
       expect.assertions(1);
-      // 745PM
-      jest.setSystemTime(dayjs("2024-01-01 19:59:59").toDate());
-      await application.bootstrap({
-        appendLibrary: LIB_MOCK_ASSISTANT,
-        appendService: {
-          Runner({ lifecycle, hass }: TServiceParams) {
-            lifecycle.onReady(async () => {
-              const turnOn = jest.spyOn(hass.call.switch, "turn_on");
-              jest.advanceTimersByTime(2 * SECOND);
-              expect(turnOn).toHaveBeenCalledWith({
-                entity_id: "switch.bedroom_lamp",
-              });
-            });
-            jest.runOnlyPendingTimersAsync();
-          },
+      await runner(
+        () => {
+          jest.setSystemTime(dayjs("2024-01-01 19:59:59").toDate());
+          jest.runOnlyPendingTimersAsync();
         },
-        configuration: {
-          boilerplate: { LOG_LEVEL: "error" },
-          hass: { MOCK_SOCKET: true, TOKEN: "--" },
+        ({ hass }) => {
+          const turnOn = jest.spyOn(hass.call.switch, "turn_on");
+          jest.advanceTimersByTime(2 * SECOND);
+          expect(turnOn).toHaveBeenCalledWith({
+            entity_id: "switch.bedroom_lamp",
+          });
         },
-      });
+      );
     });
   });
 });

--- a/src/testing/workflow.spec.ts
+++ b/src/testing/workflow.spec.ts
@@ -8,7 +8,7 @@ import {
 import dayjs from "dayjs";
 
 import { LIB_HASS } from "..";
-import { CreateTestRunner, LIB_MOCK_ASSISTANT } from "../mock_assistant";
+import { CreateTestRunner } from "../mock_assistant";
 
 describe("Workflows", () => {
   const application = CreateApplication({


### PR DESCRIPTION
#### Changes

**Enhancement for unit testing**

- Add `HassConfig` / `hass.fetch.getConfig()` to fixtures file. This stores information such as lat/long, used for solar calculations in the `automation` library
- Additional standard tools and tweaks for unit testing flows to make things act more predictably with less code

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme and [docs](https://docs.digital-alchemy.app/) (updated or not needed)
- [x] Tests (added, updated or not needed)
