### PR TITLE
Entity load retry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@digital-alchemy/hass",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digital-alchemy/hass",
-      "version": "0.3.23",
+      "version": "0.3.24",
       "license": "MIT",
       "dependencies": {
-        "@digital-alchemy/core": "^0.3.13",
+        "@digital-alchemy/core": "^0.3.14",
         "dayjs": "^1.11.11",
         "prom-client": "^15.1.2",
         "ws": "^8.17.0"
@@ -1190,9 +1190,9 @@
       }
     },
     "node_modules/@digital-alchemy/core": {
-      "version": "0.3.13",
-      "resolved": "https://registry.npmjs.org/@digital-alchemy/core/-/core-0.3.13.tgz",
-      "integrity": "sha512-fBhbffcF9FVwTwN0prM8Gbc6LcPu3E7c0GsJyj0MmdWqU+938eWCnswDGa5kMsjZu9j+PpmOSmPpu/kxq2KjAQ==",
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@digital-alchemy/core/-/core-0.3.14.tgz",
+      "integrity": "sha512-O1gGpXSgN+6TpXw6QsyVxZu0MyA0ctLpw5BJNIiQg5Ec609hYdH7LCvoe18Lw70xwHG3GQ8prWz8Jk+C/C1y/A==",
       "dependencies": {
         "chalk": "^5.3.0",
         "dayjs": "^1.11.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@digital-alchemy/hass",
-  "version": "0.3.21",
+  "version": "0.3.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@digital-alchemy/hass",
-      "version": "0.3.21",
+      "version": "0.3.23",
       "license": "MIT",
       "dependencies": {
         "@digital-alchemy/core": "^0.3.13",
@@ -20,7 +20,7 @@
       "devDependencies": {
         "@cspell/eslint-plugin": "^8.7.0",
         "@digital-alchemy/synapse": "^0.3.5",
-        "@digital-alchemy/type-writer": "^0.3.11",
+        "@digital-alchemy/type-writer": "^0.3.12",
         "@types/figlet": "^1.5.8",
         "@types/jest": "^29.5.12",
         "@types/js-yaml": "^4.0.9",
@@ -1219,15 +1219,18 @@
       }
     },
     "node_modules/@digital-alchemy/hass": {
-      "version": "0.3.21",
-      "resolved": "https://registry.npmjs.org/@digital-alchemy/hass/-/hass-0.3.21.tgz",
-      "integrity": "sha512-6/8j8T4tl33e7oYI80qXObcYcU0e7iZ9+Bq/D8LxwV/kQMk3LUyJaoNCqHD/7lfcI2oqJCrBeO/Op/TjK4trQw==",
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/@digital-alchemy/hass/-/hass-0.3.23.tgz",
+      "integrity": "sha512-z4dMEHKFX+ZLglHXW0SqlFl7/5YhoV7/6J8JzxUgbCIwRSkYwhZYi3znttRsPeOtqsGj4PL+Zktf20evTx+EMg==",
       "dev": true,
       "dependencies": {
-        "@digital-alchemy/core": "^0.3.12",
-        "dayjs": "^1.11.10",
-        "prom-client": "^15.1.1",
-        "ws": "^8.16.0"
+        "@digital-alchemy/core": "^0.3.13",
+        "dayjs": "^1.11.11",
+        "prom-client": "^15.1.2",
+        "ws": "^8.17.0"
+      },
+      "bin": {
+        "mock-assistant": "dist/mock_assistant/main.js"
       },
       "engines": {
         "node": ">=20"
@@ -1250,13 +1253,13 @@
       }
     },
     "node_modules/@digital-alchemy/type-writer": {
-      "version": "0.3.11",
-      "resolved": "https://registry.npmjs.org/@digital-alchemy/type-writer/-/type-writer-0.3.11.tgz",
-      "integrity": "sha512-xY/WpOOvCerbalC0nv7mDmt1ip6mm0P50Xv8UPaK+mLsjENC8zVYHaUIZbBvnSFw8bPBQ4161pscfGd567lImQ==",
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/@digital-alchemy/type-writer/-/type-writer-0.3.12.tgz",
+      "integrity": "sha512-yxBtY4zcnxlYUYvC+6p5IuhDDnz+Um99kPSC/5kd278jMNJ/oZ1S+pGAZwZ6O/CLI33ovtStp2bbynexouNpfg==",
       "dev": true,
       "dependencies": {
-        "@digital-alchemy/core": "^0.3.12",
-        "@digital-alchemy/hass": "^0.3.21",
+        "@digital-alchemy/core": "^0.3.13",
+        "@digital-alchemy/hass": "^0.3.22",
         "js-yaml": "^4.1.0"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@digital-alchemy/hass",
   "repository": "https://github.com/Digital-Alchemy-TS/hass",
   "homepage": "https://docs.digital-alchemy.app/Hass",
-  "version": "0.3.23",
+  "version": "0.3.24",
   "scripts": {
     "build": "rm -rf dist/; tsc",
     "lint": "eslint src",
@@ -37,7 +37,7 @@
   "devDependencies": {
     "@cspell/eslint-plugin": "^8.7.0",
     "@digital-alchemy/synapse": "^0.3.5",
-    "@digital-alchemy/type-writer": "^0.3.11",
+    "@digital-alchemy/type-writer": "^0.3.12",
     "@types/figlet": "^1.5.8",
     "@types/jest": "^29.5.12",
     "@types/js-yaml": "^4.0.9",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@digital-alchemy/core": "^0.3.13",
+    "@digital-alchemy/core": "^0.3.14",
     "dayjs": "^1.11.11",
     "prom-client": "^15.1.2",
     "ws": "^8.17.0"

--- a/src/extensions/entity.extension.ts
+++ b/src/extensions/entity.extension.ts
@@ -76,8 +76,7 @@ export type ByIdProxy<ENTITY_ID extends PICK_ENTITY> =
     removeAllListeners: () => void;
   };
 
-const MAX_ATTEMPTS = 50;
-const FAILED_LOAD_DELAY = 5;
+const MAX_ATTEMPTS = 10;
 const UNLIMITED = 0;
 const RECENT = 5;
 
@@ -299,7 +298,7 @@ export function EntityManager({
     // - Fetch list of entities
     const states = await hass.fetch.getAllEntities();
     // - Keep retrying until max failures reached
-    if (is.empty(states)) {
+    if (!is.array(states) || is.empty(states)) {
       if (recursion > MAX_ATTEMPTS) {
         logger.fatal(
           { name: refresh },
@@ -308,12 +307,12 @@ export function EntityManager({
         exit();
       }
       logger.warn(
-        { name: refresh },
+        { name: refresh, response: states },
         "failed to retrieve entity list. retrying {%s}/[%s]",
         recursion,
         MAX_ATTEMPTS,
       );
-      await sleep(FAILED_LOAD_DELAY * SECOND);
+      await sleep(config.hass.RETRY_INTERVAL * SECOND);
       await refresh(recursion + INCREMENT);
       return;
     }
@@ -395,7 +394,6 @@ export function EntityManager({
     await hass.entity.refresh();
   });
 
-  // #MARK: AddLabel
   async function AddLabel({ entity, label }: EditLabelOptions) {
     const current = await EntityGet(entity);
     if (current?.labels?.includes(label)) {

--- a/src/extensions/entity.extension.ts
+++ b/src/extensions/entity.extension.ts
@@ -386,11 +386,11 @@ export function EntityManager({
   }
 
   // #MARK: onPostConfig
-  lifecycle.onPostConfig(async () => {
+  lifecycle.onPostConfig(async function HassEntityPostConfig() {
     if (!config.hass.AUTO_CONNECT_SOCKET) {
       return;
     }
-    logger.debug({ name: "onPostConfig" }, `pre populate {MASTER_STATE}`);
+    logger.debug({ name: HassEntityPostConfig }, `pre populate {MASTER_STATE}`);
     await hass.entity.refresh();
   });
 

--- a/src/hass.module.ts
+++ b/src/hass.module.ts
@@ -65,7 +65,8 @@ export const LIB_HASS = CreateLibrary({
     },
     RETRY_INTERVAL: {
       default: 5,
-      description: "How often to retry connecting on connection failure (ms).",
+      description:
+        "How often to retry connecting on connection failure (seconds).",
       type: "number",
     },
     SOCKET_AVG_DURATION: {

--- a/src/testing/entity.spec.ts
+++ b/src/testing/entity.spec.ts
@@ -5,6 +5,7 @@ import {
   TServiceParams,
 } from "@digital-alchemy/core";
 
+import { ENTITY_STATE, PICK_ENTITY } from "../helpers";
 import { CreateTestingApplication, SILENT_BOOT } from "../mock_assistant";
 
 describe("Entity", () => {
@@ -35,6 +36,74 @@ describe("Entity", () => {
       });
       await application.bootstrap(
         SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
+      );
+    });
+  });
+
+  describe("Refresh", () => {
+    it("should attempt to load entities onBootstrap", async () => {
+      expect.assertions(2);
+      application = CreateTestingApplication({
+        Test({ lifecycle, hass }: TServiceParams) {
+          const spy = jest
+            .spyOn(hass.entity, "refresh")
+            .mockImplementation(async () => undefined);
+
+          lifecycle.onPostConfig(function latePostConfig() {
+            expect(spy).toHaveBeenCalled();
+          }, -1);
+          lifecycle.onPostConfig(function earlyPostConfig() {
+            expect(spy).not.toHaveBeenCalled();
+          }, 0);
+        },
+      });
+      await application.bootstrap(
+        SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
+      );
+    });
+
+    it("should not attempt to load entities onBootstrap if AUTO_CONNECT_SOCKET is false", async () => {
+      expect.assertions(1);
+      application = CreateTestingApplication({
+        Test({ lifecycle, hass }: TServiceParams) {
+          const spy = jest
+            .spyOn(hass.entity, "refresh")
+            .mockImplementation(async () => undefined);
+
+          lifecycle.onBootstrap(() => {
+            expect(spy).not.toHaveBeenCalled();
+          });
+        },
+      });
+      await application.bootstrap(
+        SILENT_BOOT(
+          { hass: { AUTO_CONNECT_SOCKET: false, MOCK_SOCKET: true } },
+          true,
+        ),
+      );
+    });
+
+    it("should retry on failure", async () => {
+      expect.assertions(1);
+      application = CreateTestingApplication({
+        Test({ lifecycle, hass }: TServiceParams) {
+          const responses = [
+            { text: "502 Bad Gateway" },
+            { text: "502 Bad Gateway" },
+            { text: "502 Bad Gateway" },
+            [],
+            [{ entity_id: "sensor.magic" } as ENTITY_STATE<PICK_ENTITY>],
+          ];
+          const spy = jest
+            .spyOn(hass.fetch, "getAllEntities")
+            // @ts-expect-error it happens
+            .mockImplementation(async () => responses.shift());
+
+          lifecycle.onBootstrap(() => expect(spy).toHaveBeenCalledTimes(5));
+        },
+      });
+      await application.bootstrap(
+        SILENT_BOOT({ hass: { MOCK_SOCKET: true, RETRY_INTERVAL: 0 } }, true),
       );
     });
   });


### PR DESCRIPTION
#### Changes

- Updated entity refresh retry interval to be configurable based on the same `RETRY_INTERVAL` configuration used by the socket
- Updated check for failed refresh to handle **502 Bad Gateway** messages, and other non-entity list responses

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme and [docs](https://docs.digital-alchemy.app/) (updated or not needed)
- [x] Tests (added, updated or not needed)
