### PR TITLE
byUniqueId

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@digital-alchemy/hass",
   "repository": "https://github.com/Digital-Alchemy-TS/hass",
   "homepage": "https://docs.digital-alchemy.app/Hass",
-  "version": "0.3.26",
+  "version": "0.3.27",
   "scripts": {
     "build": "rm -rf dist/; tsc",
     "lint": "eslint src",

--- a/src/extensions/entity.extension.ts
+++ b/src/extensions/entity.extension.ts
@@ -467,6 +467,18 @@ export function EntityManager({
     });
   });
 
+  // #MARK: byUniqueId
+  function byUniqueId<ID extends PICK_ENTITY>(unique_id: string) {
+    const entity = hass.entity.registry.current.find(
+      i => i.unique_id === unique_id,
+    ) as EntityRegistryItem<ID>;
+    if (!entity) {
+      logger.error({ name: byUniqueId, unique_id }, `could not find an entity`);
+      return undefined;
+    }
+    return hass.entity.byId<ID>(entity.entity_id);
+  }
+
   // #MARK: byLabel
   function byLabel<LABEL extends TLabelId, DOMAIN extends ALL_DOMAINS>(
     label: LABEL,
@@ -597,6 +609,11 @@ export function EntityManager({
      * search out ids by platform
      */
     byPlatform,
+
+    /**
+     * looks up entity_id reference by the unique id in the registry, and returns the entity reference
+     */
+    byUniqueId,
 
     /**
      * Internal library use only

--- a/src/mock_assistant/extensions/fixtures.extension.ts
+++ b/src/mock_assistant/extensions/fixtures.extension.ts
@@ -27,6 +27,8 @@ export function Fixtures({
   hass.floor.list = async () => mock_assistant.fixtures.data?.floors ?? [];
   hass.label.list = async () => mock_assistant.fixtures.data?.labels ?? [];
   hass.device.list = async () => mock_assistant.fixtures.data?.devices ?? [];
+  hass.entity.registry.list = async () =>
+    mock_assistant.fixtures.data.entity_registry ?? [];
   hass.fetch.getAllEntities = async () =>
     mock_assistant.fixtures.data?.entities ?? [];
   hass.fetch.listServices = async () =>

--- a/src/testing/entity.spec.ts
+++ b/src/testing/entity.spec.ts
@@ -56,6 +56,23 @@ describe("Entity", () => {
         SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
       );
     });
+
+    it("should return undefined for no matches", async () => {
+      expect.assertions(2);
+      application = CreateTestingApplication({
+        Test({ lifecycle, hass }: TServiceParams) {
+          lifecycle.onReady(() => {
+            const entity = hass.entity.byUniqueId(
+              "5622d76001a335e3ea893c4d60d31b3d-previous_dawn",
+            );
+            expect(entity).not.toBeDefined();
+          });
+        },
+      });
+      await application.bootstrap(
+        SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
+      );
+    });
   });
 
   describe("Refresh", () => {

--- a/src/testing/entity.spec.ts
+++ b/src/testing/entity.spec.ts
@@ -38,6 +38,24 @@ describe("Entity", () => {
         SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
       );
     });
+
+    it("should find entities by unique_id", async () => {
+      expect.assertions(2);
+      application = CreateTestingApplication({
+        Test({ lifecycle, hass }: TServiceParams) {
+          lifecycle.onReady(() => {
+            const entity = hass.entity.byUniqueId<"sensor.sun_next_dawn">(
+              "5622d76001a335e3ea893c4d60d31b3d-next_dawn",
+            );
+            expect(entity).toBeDefined();
+            expect(entity.entity_id).toBe("sensor.sun_next_dawn");
+          });
+        },
+      });
+      await application.bootstrap(
+        SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
+      );
+    });
   });
 
   describe("Refresh", () => {

--- a/src/testing/entity.spec.ts
+++ b/src/testing/entity.spec.ts
@@ -58,7 +58,7 @@ describe("Entity", () => {
     });
 
     it("should return undefined for no matches", async () => {
-      expect.assertions(2);
+      expect.assertions(1);
       application = CreateTestingApplication({
         Test({ lifecycle, hass }: TServiceParams) {
           lifecycle.onReady(() => {


### PR DESCRIPTION
#### Changes

Added method `hass.entity.byUniqueId`. This will take in the unique id of an entity, and return back an entity reference. 

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme and [docs](https://docs.digital-alchemy.app/) (updated or not needed)
- [x] Tests (added, updated or not needed)
