### PR TITLE
Log errors on early calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@digital-alchemy/hass",
   "repository": "https://github.com/Digital-Alchemy-TS/hass",
   "homepage": "https://docs.digital-alchemy.app/Hass",
-  "version": "0.3.28",
+  "version": "0.3.29",
   "scripts": {
     "build": "rm -rf dist/; tsc",
     "lint": "eslint src",

--- a/src/extensions/call-proxy.extension.ts
+++ b/src/extensions/call-proxy.extension.ts
@@ -123,9 +123,11 @@ export function CallProxy({ logger, lifecycle, hass, config }: TServiceParams) {
     return new Proxy(rawProxy as iCallService, {
       get: (_, domain: ALL_SERVICE_DOMAINS) => {
         if (loaded) {
-          logger.error(
-            `attempted to use {hass.call} before data loaded. use {lifecycle.onReady}`,
-          );
+          lifecycle.onReady(() => {
+            logger.error(
+              `attempted to use {hass.call} before data loaded. use {lifecycle.onReady}`,
+            );
+          });
         }
         return rawProxy[domain];
       },

--- a/src/extensions/call-proxy.extension.ts
+++ b/src/extensions/call-proxy.extension.ts
@@ -23,6 +23,7 @@ const FAILED = 1;
 
 export function CallProxy({ logger, lifecycle, hass, config }: TServiceParams) {
   let services: HassServiceDTO[];
+  let loaded = false;
   const rawProxy = {} as Record<string, Record<string, unknown>>;
   /**
    * Describe the current services, and build up a proxy api based on that.
@@ -39,6 +40,7 @@ export function CallProxy({ logger, lifecycle, hass, config }: TServiceParams) {
       `runtime populate service interfaces`,
     );
     await loadServiceList();
+    loaded = true;
   });
 
   async function loadServiceList(recursion = START): Promise<void> {
@@ -119,7 +121,14 @@ export function CallProxy({ logger, lifecycle, hass, config }: TServiceParams) {
 
   function buildCallProxy(): iCallService {
     return new Proxy(rawProxy as iCallService, {
-      get: (_, domain: ALL_SERVICE_DOMAINS) => rawProxy[domain],
+      get: (_, domain: ALL_SERVICE_DOMAINS) => {
+        if (loaded) {
+          logger.error(
+            `attempted to use {hass.call} before data loaded. use {lifecycle.onReady}`,
+          );
+        }
+        return rawProxy[domain];
+      },
     });
   }
 

--- a/src/extensions/entity.extension.ts
+++ b/src/extensions/entity.extension.ts
@@ -101,10 +101,12 @@ export function EntityManager({
   let lastRefresh: Dayjs;
   function warnEarly(method: string) {
     if (!init) {
-      logger.error(
-        "attempted to use [%s] before application booted. use {lifecycle.onReady}",
-        method,
-      );
+      lifecycle.onReady(() => {
+        logger.error(
+          "attempted to use [%s] before application booted. use {lifecycle.onReady}",
+          method,
+        );
+      });
     }
   }
 


### PR DESCRIPTION
#### Changes

Calling `hass.entity` methods, or `hass.call` prior to the application initializing will result in an error log `onReady`, alerting to the incorrect code pattern

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme and [docs](https://docs.digital-alchemy.app/) (updated or not needed)
- [x] Tests (added, updated or not needed)
