### PR TITLE
Domain service calls from entities

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@digital-alchemy/hass",
   "repository": "https://github.com/Digital-Alchemy-TS/hass",
   "homepage": "https://docs.digital-alchemy.app/Hass",
-  "version": "0.3.32",
+  "version": "0.3.33",
   "scripts": {
     "build": "rm -rf dist/; tsc",
     "lint": "eslint src",

--- a/src/extensions/config.extension.ts
+++ b/src/extensions/config.extension.ts
@@ -1,8 +1,25 @@
 /* eslint-disable @typescript-eslint/no-magic-numbers */
-import { asyncNoop, is, TServiceParams } from "@digital-alchemy/core";
+import {
+  asyncNoop,
+  INCREMENT,
+  is,
+  SECOND,
+  sleep,
+  START,
+  TServiceParams,
+} from "@digital-alchemy/core";
 import { env, exit } from "process";
 
-import { PostConfigPriorities } from "..";
+import {
+  ALL_SERVICE_DOMAINS,
+  HassServiceDTO,
+  iCallService,
+  PostConfigPriorities,
+} from "..";
+
+const MAX_ATTEMPTS = 50;
+const FAILED = 1;
+
 export function Configure({
   logger,
   lifecycle,
@@ -60,4 +77,47 @@ export function Configure({
       exit(0);
     }
   }, PostConfigPriorities.VALIDATE);
+
+  let services: HassServiceDTO[];
+  async function loadServiceList(recursion = START): Promise<void> {
+    logger.info({ name: loadServiceList }, `fetching service list`);
+    services = await hass.fetch.listServices();
+    if (is.empty(services)) {
+      if (recursion > MAX_ATTEMPTS) {
+        logger.fatal(
+          { name: loadServiceList },
+          `failed to load service list from Home Assistant`,
+        );
+        exit(FAILED);
+      }
+      logger.warn(
+        { name: loadServiceList },
+        "failed to retrieve {service} list. Retrying {%s}/[%s]",
+        recursion,
+        MAX_ATTEMPTS,
+      );
+      await sleep(config.hass.RETRY_INTERVAL * SECOND);
+      await loadServiceList(recursion + INCREMENT);
+    }
+    checkedServices = new Map();
+  }
+  let checkedServices = new Map<string, boolean>();
+
+  return {
+    getServices: () => services,
+    isService: <DOMAIN extends ALL_SERVICE_DOMAINS>(
+      domain: DOMAIN,
+      service: string,
+    ): service is Extract<keyof iCallService[DOMAIN], string> => {
+      if (checkedServices.has(service)) {
+        return checkedServices.get(service);
+      }
+      const exists = services.some(
+        i => i.domain === domain && !is.undefined(i.services[service]),
+      );
+      checkedServices.set(service, exists);
+      return exists;
+    },
+    loadServiceList,
+  };
 }

--- a/src/extensions/entity.extension.ts
+++ b/src/extensions/entity.extension.ts
@@ -16,6 +16,7 @@ import { Get } from "type-fest";
 
 import {
   ALL_DOMAINS,
+  ALL_SERVICE_DOMAINS,
   ByIdProxy,
   domain,
   EditLabelOptions,
@@ -125,6 +126,7 @@ export function EntityManager({
   function byId<ENTITY_ID extends PICK_ENTITY>(
     entity_id: ENTITY_ID,
   ): ByIdProxy<ENTITY_ID> {
+    const entity_domain = domain(entity_id) as ALL_SERVICE_DOMAINS;
     if (!ENTITY_PROXIES.has(entity_id)) {
       ENTITY_PROXIES.set(
         entity_id,
@@ -168,6 +170,15 @@ export function EntityManager({
                       done(entity satisfies ENTITY_STATE<ENTITY_ID>),
                   );
                 });
+            }
+            if (hass.configure.isService(entity_domain, property)) {
+              return async function (data = {}) {
+                // @ts-expect-error it's fine
+                return await hass.call[entity_domain][property]({
+                  entity_id,
+                  ...data,
+                });
+              };
             }
             return proxyGetLogic(entity_id, property);
           },


### PR DESCRIPTION
#### Changes

- Added the ability to call services from entity proxies for services matching the same domain

```typescript
const switchEntity = hass.entity.byId("switch.example_switch");
switchEntity.turn_on();
switchEntity.toggle();
const lightEntity = hass.entity.byId("light.example_light")
lightEntity.turn_on({ .... })
```

![2024-06-08_11-58](https://github.com/Digital-Alchemy-TS/hass/assets/35661840/b2efdd57-5d87-4257-be7f-4ade2717dad2)

#### Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [ ] Readme and [docs](https://docs.digital-alchemy.app/) (updated or not needed)
- [ ] Tests (added, updated or not needed)
