### PR TITLE
add missing action options and better naming

### DIFF
--- a/src/dynamic.ts
+++ b/src/dynamic.ts
@@ -5,9 +5,9 @@
 /* eslint-disable @typescript-eslint/ban-types */
 // @ts-nocheck
 import {
-  ActionableNotification,
-  AndroidActionableNotification,
-  AppleActionableNotification,
+  NotificationData,
+  AndroidNotificationData,
+  AppleNotificationData,
   PICK_ENTITY,
 } from "./helpers";
 
@@ -2691,8 +2691,8 @@ export type iCallService = {
        * > object: null
        * > ```
        */
-      data?: ActionableNotification &
-        (AndroidActionableNotification | AppleActionableNotification);
+      data?: NotificationData &
+      (AndroidNotificationData | AppleNotificationData);
       /**
        * ## message
        *
@@ -2761,8 +2761,8 @@ export type iCallService = {
        * > object: null
        * > ```
        */
-      data?: ActionableNotification &
-        (AndroidActionableNotification | AppleActionableNotification);
+      data?: NotificationData &
+      (AndroidNotificationData | AppleNotificationData);
       /**
        * ## Message
        *

--- a/src/helpers/notify.helper.ts
+++ b/src/helpers/notify.helper.ts
@@ -1,4 +1,4 @@
-export type AppleActionableNotificationPush = {
+export type AppleNotificationPush = {
   /**
    * **iOS | MacOS**
    *
@@ -32,7 +32,73 @@ export type AppleActionableNotificationPush = {
   presentation_options?: ["alert" | "badge" | "sound"];
 };
 
-export type AppleActionableNotification = {
+export type NotificationAction = {
+  /**
+   * Key passed back in events.
+   * When set to `REPLY`, you will be prompted for text to send with the event.
+   */
+  action: "REPLY" | "URI" | string;
+  /**
+   * Shown on the action button to the user.
+   */
+  title: string;
+  /**
+   * The URI to open when selected.
+   * Android requires setting the action string to `URI` to use this key. [More Info](https://companion.home-assistant.io/docs/notifications/actionable-notifications/#uri-values).
+   */
+  uri?: string;
+};
+
+export type AndroidNotificationActionOptions = {};
+
+export type AppleNotificationActionOptions = {
+  /**
+   * **iOS | MacOS**
+   * 
+   * Set to `foreground` to launch the app when tapped. Defaults to background which just fires the event.
+   * This is automatically set to foreground when providing a uri.
+   */
+  activationMode?: "foreground" | "background";
+  /**
+   * **iOS | MacOS**
+   * 
+   * Set to `true` to require a password to fire the event.
+   */
+  authenticationRequired?: boolean;
+  /**
+   * **iOS | MacOS**
+   * 
+   * Set to `true` to color the actions title red.
+   */
+  destructive?: boolean;
+  /**
+   * **iOS | MacOS**
+   * 
+   * Set to `textInput` to prompt for text to return with the event. This also occurs when setting the action to `REPLY`.
+   */
+  behavior?: "textInput";
+  /**
+   * **iOS | MacOS**
+   * 
+   * Title to use for text input for actions that prompt.
+   */
+  textInputButtonTitle?: string;
+  /**
+   * **iOS | MacOS**
+   * 
+   * Placeholder to use for text input for actions that prompt.
+   */
+  textInputPlaceholder?: string;
+  /**
+   * **iOS | MacOS**
+   * 
+   * The icon to use for the notification.
+   * * [More info](https://companion.home-assistant.io/docs/notifications/actionable-notifications#icon-values)
+   */
+  icon?: string;
+}
+
+export type AppleNotificationData = {
   /**
    * **iOS | MacOS**
    *
@@ -48,10 +114,14 @@ export type AppleActionableNotification = {
    * [More info](https://companion.home-assistant.io/docs/notifications/notifications-basic#subtitle--subject)
    */
   subtitle?: string;
-  push?: AppleActionableNotificationPush;
+  push?: AppleNotificationPush;
+  /**
+   * iOS Suports ~10 actions.
+   */
+  actions: Array<NotificationAction & AppleNotificationActionOptions>;
 };
 
-export type AndroidActionableNotification = {
+export type AndroidNotificationData = {
   /**
    * **Android**
    *
@@ -202,29 +272,14 @@ export type AndroidActionableNotification = {
    * [More info](https://companion.home-assistant.io/docs/notifications/notifications-basic#android-auto-visibility)
    */
   car_ui?: boolean;
+
+  /**
+   * Android Suports 3 actions.
+   */
+  actions: Array<NotificationAction & AndroidNotificationActionOptions>;
 };
 
-export type ActionableNotification = {
-  /**
-   * Android allows 3 actions.
-   * iOS allows around 10 actions.
-   */
-  actions?: {
-    /**
-     * Key passed back in events.
-     * When set to `REPLY`, you will be prompted for text to send with the event.
-     */
-    action: "REPLY" | "URI" | string;
-    /**
-     * Shown on the action button to the user.
-     */
-    title: string;
-    /**
-     * The URI to open when selected.
-     * Android requires setting the action string to `URI` to use this key. [More Info](https://companion.home-assistant.io/docs/notifications/actionable-notifications/#uri-values).
-     */
-    uri?: string;
-  }[];
+export type NotificationData = {
   /**
    * The group to which the notification belongs.
    * [More info](https://companion.home-assistant.io/docs/notifications/notifications-basic#grouping)


### PR DESCRIPTION
## 📬 Changes

I updated the names of these types a bit as most of these types are just for notifications (no action required). I also added missing types for apple specific action options and a placeholder for the same from android.

## 🗒️ Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [X] Readme and [docs](https://docs.digital-alchemy.app/) (updated or not needed)
- [X] Tests (added, updated or not needed)
