### PR TITLE
idBy.area improvements

### DIFF
--- a/fixtures.json
+++ b/fixtures.json
@@ -26,6 +26,15 @@
       "labels": [],
       "name": "Bedroom",
       "picture": null
+    },
+    {
+      "aliases": [],
+      "area_id": "test",
+      "floor_id": "upstairs",
+      "icon": null,
+      "labels": [],
+      "name": "Test",
+      "picture": null
     }
   ],
   "devices": [
@@ -66,6 +75,32 @@
       "entry_type": "service",
       "hw_version": null,
       "id": "e58841e47cf86097b310316e55d6bb12",
+      "identifiers": [
+        [
+          "holiday",
+          "05ecbbc6111791b6baacbbb60397db14"
+        ]
+      ],
+      "labels": [],
+      "manufacturer": null,
+      "model": null,
+      "name_by_user": null,
+      "name": "United States, TX",
+      "serial_number": null,
+      "sw_version": null,
+      "via_device_id": null
+    },
+    {
+      "area_id": "test",
+      "configuration_url": null,
+      "config_entries": [
+        "05ecbbc6111791b6baacaaa60397db14"
+      ],
+      "connections": [],
+      "disabled_by": null,
+      "entry_type": "service",
+      "hw_version": null,
+      "id": "e59941e47cf86097b310316e55d6bb12",
       "identifiers": [
         [
           "holiday",
@@ -397,6 +432,75 @@
       }
     },
     {
+      "entity_id": "sensor.living_room_temperature",
+      "state": "23.5",
+      "attributes": {
+        "unit_of_measurement": "°C",
+        "friendly_name": "Living Room Temperature",
+        "device_class": "temperature"
+      },
+      "last_changed": "2024-08-30T14:02:12.345678+00:00",
+      "last_reported": "2024-08-30T14:02:12.345678+00:00",
+      "last_updated": "2024-08-30T14:02:12.345678+00:00",
+      "context": {
+        "id": "02CDEFGHIJK1L2MNO3PQRS4TU5",
+        "parent_id": null,
+        "user_id": null
+      }
+    },
+    {
+      "entity_id": "light.bedroom_light",
+      "state": "on",
+      "attributes": {
+        "brightness": 255,
+        "friendly_name": "Bedroom Light",
+        "supported_features": 41
+      },
+      "last_changed": "2024-08-30T14:03:21.567890+00:00",
+      "last_reported": "2024-08-30T14:03:21.567890+00:00",
+      "last_updated": "2024-08-30T14:03:21.567890+00:00",
+      "context": {
+        "id": "03UVWXYZABCDE123FGHI456JKL7",
+        "parent_id": null,
+        "user_id": null
+      }
+    },
+    {
+      "entity_id": "climate.hallway_thermostat",
+      "state": "cool",
+      "attributes": {
+        "current_temperature": 22,
+        "target_temperature": 20,
+        "hvac_mode": "cool",
+        "friendly_name": "Hallway Thermostat",
+        "supported_features": 1
+      },
+      "last_changed": "2024-08-30T14:04:44.123456+00:00",
+      "last_reported": "2024-08-30T14:04:44.123456+00:00",
+      "last_updated": "2024-08-30T14:04:44.123456+00:00",
+      "context": {
+        "id": "04MNOPQRSTUV8WX9YZABCDE123",
+        "parent_id": null,
+        "user_id": null
+      }
+    },
+    {
+      "entity_id": "binary_sensor.garage_door",
+      "state": "off",
+      "attributes": {
+        "device_class": "door",
+        "friendly_name": "Garage Door Sensor"
+      },
+      "last_changed": "2024-08-30T14:05:32.789012+00:00",
+      "last_reported": "2024-08-30T14:05:32.789012+00:00",
+      "last_updated": "2024-08-30T14:05:32.789012+00:00",
+      "context": {
+        "id": "05FGHIJKLMNO4PQR5STUV6789WX",
+        "parent_id": null,
+        "user_id": null
+      }
+    },
+    {
       "entity_id": "calendar.united_states_tx",
       "state": "off",
       "attributes": {
@@ -419,6 +523,86 @@
     }
   ],
   "entity_registry": [
+    {
+      "area_id": "living_room",
+      "categories": {},
+      "config_entry_id": "9f1b2c34d0a7498d9ecbbb5d673c5e4a",
+      "device_id": "e59941e47cf86097b310316e55d6bb12",
+      "disabled_by": null,
+      "entity_category": null,
+      "entity_id": "sensor.living_room_temperature",
+      "has_entity_name": true,
+      "hidden_by": null,
+      "icon": "mdi:thermometer",
+      "id": "4a7d8f7d8b9c4e6db5a3c7f1d1a9e4c7",
+      "labels": [],
+      "name": null,
+      "options": {},
+      "original_name": "Living Room Temperature",
+      "platform": "sensor",
+      "translation_key": null,
+      "unique_id": "9f1b2c34d0a7498d9ecbbb5d673c5e4a-living_room_temperature"
+    },
+    {
+      "area_id": "bedroom",
+      "categories": {},
+      "config_entry_id": "c4f9e8ab7c3b4f9e8ab9d1f6a1c2e3d4",
+      "device_id": "e59941e47cf86097b310316e55d6bb12",
+      "disabled_by": null,
+      "entity_category": null,
+      "entity_id": "light.bedroom_light",
+      "has_entity_name": true,
+      "hidden_by": null,
+      "icon": "mdi:lightbulb",
+      "id": "7c1e8d9c9b8c4e7eb5a3d9f6c1e7a3d9",
+      "labels": [],
+      "name": null,
+      "options": {},
+      "original_name": "Bedroom Light",
+      "platform": "light",
+      "translation_key": null,
+      "unique_id": "c4f9e8ab7c3b4f9e8ab9d1f6a1c2e3d4-bedroom_light"
+    },
+    {
+      "area_id": null,
+      "categories": {},
+      "config_entry_id": "a1b2c3d4e5f67890ab1c2d3e4f567890",
+      "device_id": "e59941e47cf86097b310316e55d6bb12",
+      "disabled_by": null,
+      "entity_category": null,
+      "entity_id": "climate.hallway_thermostat",
+      "has_entity_name": true,
+      "hidden_by": null,
+      "icon": "mdi:thermostat",
+      "id": "1a2b3c4d5e6f7g8h9i0j1k2l3m4n5o6p",
+      "labels": [],
+      "name": null,
+      "options": {},
+      "original_name": "Hallway Thermostat",
+      "platform": "climate",
+      "translation_key": null,
+      "unique_id": "a1b2c3d4e5f67890ab1c2d3e4f567890-hallway_thermostat"
+    },
+    {
+      "area_id": null,
+      "categories": {},
+      "config_entry_id": "b1c2d3e4f567890a1b2c3d4e5f67890b",
+      "device_id": "e59941e47cf86097b310316e55d6bb12",
+      "disabled_by": null,
+      "entity_category": null,
+      "entity_id": "binary_sensor.garage_door",
+      "has_entity_name": true,
+      "hidden_by": null,
+      "icon": "mdi:garage",
+      "id": "6p5o4n3m2l1k0j9i8h7g6f5e4d3c2b1a",
+      "labels": [],
+      "name": null,
+      "options": {},
+      "original_name": "Garage Door Sensor",
+      "platform": "binary_sensor",
+      "translation_key": null,
+      "unique_id": "b1c2d3e4f567890a1b2c3d4e5f67890b-garage_door"
+    },
     {
       "area_id": null,
       "categories": {},
@@ -444,7 +628,7 @@
       "unique_id": "5622d76001a335e3ea893c4d60d31b3d-next_dawn"
     },
     {
-      "area_id": null,
+      "area_id": "test",
       "categories": {},
       "config_entry_id": "5622d76001a335e3ea893c4d60d31b3d",
       "device_id": "308e39cf50a9fc6c30b4110724ed1f2e",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@digital-alchemy/hass",
   "repository": "https://github.com/Digital-Alchemy-TS/hass",
   "homepage": "https://docs.digital-alchemy.app",
-  "version": "24.8.2",
+  "version": "24.8.3",
   "description": "Typescript APIs for Home Assistant. Includes rest & websocket bindings",
   "scripts": {
     "build": "rm -rf dist/; tsc",
@@ -61,9 +61,9 @@
   "license": "MIT",
   "devDependencies": {
     "@cspell/eslint-plugin": "^8.8.4",
-    "@digital-alchemy/core": "^24.8.2",
-    "@digital-alchemy/synapse": "^24.8.1",
-    "@digital-alchemy/type-writer": "^24.7.2",
+    "@digital-alchemy/core": "^24.8.4",
+    "@digital-alchemy/synapse": "^24.8.2",
+    "@digital-alchemy/type-writer": "^24.8.1",
     "@types/figlet": "^1.5.8",
     "@types/jest": "^29.5.12",
     "@types/js-yaml": "^4.0.9",

--- a/src/dynamic.ts
+++ b/src/dynamic.ts
@@ -4087,6 +4087,7 @@ export type iCallService = {
 // #MARK: REGISTRY_SETUP
 export type REGISTRY_SETUP = {
   area: {
+    _test: "switch.living_room_mood_lights";
     _living_room: "switch.living_room_mood_lights";
     _kitchen: "switch.kitchen_cabinets";
     _bedroom: "switch.bedroom_lamp" | "light.bedroom_ceiling_fan";
@@ -4148,7 +4149,7 @@ export type REGISTRY_SETUP = {
 };
 
 // #MARK: TAreaId
-export type TAreaId = "living_room" | "kitchen" | "bedroom";
+export type TAreaId = "living_room" | "kitchen" | "bedroom" | "test";
 
 // #MARK: TDeviceId
 export type TDeviceId =

--- a/src/extensions/events.extension.ts
+++ b/src/extensions/events.extension.ts
@@ -11,15 +11,6 @@ import {
 
 type SimpleCallback = () => TBlackHole;
 
-const ANY_REGISTRY = [
-  AREA_REGISTRY_UPDATED,
-  DEVICE_REGISTRY_UPDATED,
-  ENTITY_REGISTRY_UPDATED,
-  FLOOR_REGISTRY_UPDATED,
-  LABEL_REGISTRY_UPDATED,
-  ZONE_REGISTRY_UPDATED,
-];
-
 export function Events({ event }: TServiceParams) {
   return {
     onAreaRegistryUpdate: (callback: SimpleCallback) =>
@@ -32,8 +23,6 @@ export function Events({ event }: TServiceParams) {
       event.on(FLOOR_REGISTRY_UPDATED, callback),
     onLabelRegistryUpdate: (callback: SimpleCallback) =>
       event.on(LABEL_REGISTRY_UPDATED, callback),
-    onRegistryUpdate: (callback: SimpleCallback) =>
-      ANY_REGISTRY.forEach(i => event.on(i, callback)),
     onZoneRegistryUpdate: (callback: SimpleCallback) =>
       event.on(ZONE_REGISTRY_UPDATED, callback),
   };

--- a/src/extensions/events.extension.ts
+++ b/src/extensions/events.extension.ts
@@ -11,6 +11,15 @@ import {
 
 type SimpleCallback = () => TBlackHole;
 
+const ANY_REGISTRY = [
+  AREA_REGISTRY_UPDATED,
+  DEVICE_REGISTRY_UPDATED,
+  ENTITY_REGISTRY_UPDATED,
+  FLOOR_REGISTRY_UPDATED,
+  LABEL_REGISTRY_UPDATED,
+  ZONE_REGISTRY_UPDATED,
+];
+
 export function Events({ event }: TServiceParams) {
   return {
     onAreaRegistryUpdate: (callback: SimpleCallback) =>
@@ -23,6 +32,8 @@ export function Events({ event }: TServiceParams) {
       event.on(FLOOR_REGISTRY_UPDATED, callback),
     onLabelRegistryUpdate: (callback: SimpleCallback) =>
       event.on(LABEL_REGISTRY_UPDATED, callback),
+    onRegistryUpdate: (callback: SimpleCallback) =>
+      ANY_REGISTRY.forEach(i => event.on(i, callback)),
     onZoneRegistryUpdate: (callback: SimpleCallback) =>
       event.on(ZONE_REGISTRY_UPDATED, callback),
   };

--- a/src/extensions/id-by.extension.ts
+++ b/src/extensions/id-by.extension.ts
@@ -41,9 +41,6 @@ export function IDByExtension({ hass, logger }: TServiceParams): IDByInterface {
     );
   }
 
-  let areaCache = new Map<TAreaId, PICK_ENTITY[]>();
-  hass.events.onRegistryUpdate(() => (areaCache = new Map()));
-
   // #MARK: byUniqueId
   function unique_id<
     UNIQUE_ID extends TUniqueId,

--- a/src/testing/id-by.spec.ts
+++ b/src/testing/id-by.spec.ts
@@ -5,6 +5,7 @@ import {
   TServiceParams,
 } from "@digital-alchemy/core";
 
+import { PICK_ENTITY } from "../helpers";
 import { CreateTestingApplication, SILENT_BOOT } from "../mock_assistant";
 
 describe("ID By", () => {
@@ -31,6 +32,30 @@ describe("ID By", () => {
             const kitchen = hass.idBy.area("kitchen");
             expect(bedroom.length).toBe(1);
             expect(kitchen.length).toBe(1);
+          });
+        },
+      });
+      await application.bootstrap(
+        SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
+      );
+    });
+
+    it("finds entities only related by device", async () => {
+      expect.assertions(1);
+      application = CreateTestingApplication({
+        Test({ lifecycle, hass }: TServiceParams) {
+          lifecycle.onReady(() => {
+            // merges 1 from direct area, 2 via device
+            // ignores 2 from the device assigned to another area
+            const list = hass.idBy.area("test") as PICK_ENTITY[];
+            const expected = [
+              "sensor.sun_next_dusk",
+              "climate.hallway_thermostat",
+              "binary_sensor.garage_door",
+            ] as PICK_ENTITY[];
+            expect(expected.every(expected => list.includes(expected))).toBe(
+              true,
+            );
           });
         },
       });

--- a/src/testing/id-by.spec.ts
+++ b/src/testing/id-by.spec.ts
@@ -30,7 +30,7 @@ describe("ID By", () => {
           lifecycle.onReady(() => {
             const bedroom = hass.idBy.area("bedroom");
             const kitchen = hass.idBy.area("kitchen");
-            expect(bedroom.length).toBe(1);
+            expect(bedroom.length).toBe(2);
             expect(kitchen.length).toBe(1);
           });
         },
@@ -71,7 +71,7 @@ describe("ID By", () => {
           lifecycle.onReady(() => {
             const bedroom = hass.idBy.area("bedroom", "light");
             const kitchen = hass.idBy.area("kitchen", "light");
-            expect(bedroom.length).toBe(0);
+            expect(bedroom.length).toBe(1);
             expect(kitchen.length).toBe(0);
           });
         },
@@ -190,7 +190,7 @@ describe("ID By", () => {
         Test({ lifecycle, hass }: TServiceParams) {
           lifecycle.onReady(() => {
             const synapse = hass.idBy.floor("downstairs");
-            expect(synapse.length).toBe(2);
+            expect(synapse.length).toBe(3);
           });
         },
       });

--- a/src/testing/ref-by.spec.ts
+++ b/src/testing/ref-by.spec.ts
@@ -123,7 +123,7 @@ describe("ID By", () => {
         Test({ lifecycle, hass }: TServiceParams) {
           lifecycle.onReady(() => {
             const sensor = hass.refBy.domain("sensor");
-            expect(sensor.length).toBe(7);
+            expect(sensor.length).toBe(8);
           });
         },
       });

--- a/src/testing/ref-by.spec.ts
+++ b/src/testing/ref-by.spec.ts
@@ -192,7 +192,7 @@ describe("ID By", () => {
           lifecycle.onReady(() => {
             const bedroom = hass.refBy.area("bedroom");
             const kitchen = hass.refBy.area("kitchen");
-            expect(bedroom.length).toBe(1);
+            expect(bedroom.length).toBe(2);
             expect(kitchen.length).toBe(1);
           });
         },
@@ -209,7 +209,7 @@ describe("ID By", () => {
           lifecycle.onReady(() => {
             const bedroom = hass.refBy.area("bedroom", "light");
             const kitchen = hass.refBy.area("kitchen", "light");
-            expect(bedroom.length).toBe(0);
+            expect(bedroom.length).toBe(1);
             expect(kitchen.length).toBe(0);
           });
         },
@@ -296,7 +296,7 @@ describe("ID By", () => {
         Test({ lifecycle, hass }: TServiceParams) {
           lifecycle.onReady(() => {
             const synapse = hass.refBy.floor("downstairs");
-            expect(synapse.length).toBe(2);
+            expect(synapse.length).toBe(3);
           });
         },
       });

--- a/yarn.lock
+++ b/yarn.lock
@@ -937,9 +937,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@digital-alchemy/core@npm:^24.6.1":
-  version: 24.6.6
-  resolution: "@digital-alchemy/core@npm:24.6.6"
+"@digital-alchemy/core@npm:^24.8.4":
+  version: 24.8.4
+  resolution: "@digital-alchemy/core@npm:24.8.4"
   dependencies:
     chalk: "npm:^5.3.0"
     dayjs: "npm:^1.11.11"
@@ -954,43 +954,23 @@ __metadata:
   dependenciesMeta:
     redis:
       optional: true
-  checksum: 10/e8b4ed60ebb6170403450da8e1d1c5e285c04a3223c6c7aff5b5c6da05774d029087303fa356b7194912ff8f4626bcb7126f024d535217e9c3b14c57a141fd09
+  checksum: 10/51e44d5d3fd104c129e1233f73c16ad65c8471213893f655b93a25e342f1342dab52237187452752be046605e3da1df5e6eb811fdfddf7a2537e912dc58348ae
   languageName: node
   linkType: hard
 
-"@digital-alchemy/core@npm:^24.8.2":
-  version: 24.8.2
-  resolution: "@digital-alchemy/core@npm:24.8.2"
+"@digital-alchemy/fastify-extension@npm:^24.8.1":
+  version: 24.8.1
+  resolution: "@digital-alchemy/fastify-extension@npm:24.8.1"
   dependencies:
-    chalk: "npm:^5.3.0"
-    dayjs: "npm:^1.11.11"
-    dotenv: "npm:^16.4.5"
-    ini: "npm:^4.1.3"
-    js-yaml: "npm:^4.1.0"
-    minimist: "npm:^1.2.8"
-    node-cache: "npm:^5.1.2"
-    node-cron: "npm:^3.0.3"
-    prom-client: "npm:^15.1.2"
-    redis: "npm:^4.6.14"
-  dependenciesMeta:
-    redis:
-      optional: true
-  checksum: 10/68e9676a9a33daba073e2d351bac4738bd20ea9d5c3ef41b4d8d2ca813649af108cbd7023e0803b771c4c0ccc6da520c9756b52d0b0dfcfd06fee7178ab7e162
-  languageName: node
-  linkType: hard
-
-"@digital-alchemy/fastify-extension@npm:*":
-  version: 24.6.1
-  resolution: "@digital-alchemy/fastify-extension@npm:24.6.1"
-  dependencies:
-    "@digital-alchemy/core": "npm:^24.6.1"
     "@fastify/auth": "npm:^4.6.1"
     "@fastify/basic-auth": "npm:^5.1.1"
     "@fastify/jwt": "npm:^8.0.0"
     dayjs: "npm:^1.11.10"
     fastify: "npm:^4.26.2"
     prom-client: "npm:^15.1.1"
-  checksum: 10/efbb68b36ddf8b21eea81db483e18589efe3f909cf4c5e74b6dfb17dbdcf010719c8ee1335a1cf256c45ecd9cdb8f4e09e031697f99625d97049e05d642bfe7b
+  peerDependencies:
+    "@digital-alchemy/core": "*"
+  checksum: 10/251d887b10ff6758396eb89ebb4c27ac465085a7b0e3b25688cb134c7c7c4819d2a962f89beaa6247094bace394a08190086cc0d7fb5ede6dc6d55bee6cf87dc
   languageName: node
   linkType: hard
 
@@ -999,9 +979,9 @@ __metadata:
   resolution: "@digital-alchemy/hass@workspace:."
   dependencies:
     "@cspell/eslint-plugin": "npm:^8.8.4"
-    "@digital-alchemy/core": "npm:^24.8.2"
-    "@digital-alchemy/synapse": "npm:^24.8.1"
-    "@digital-alchemy/type-writer": "npm:^24.7.2"
+    "@digital-alchemy/core": "npm:^24.8.4"
+    "@digital-alchemy/synapse": "npm:^24.8.2"
+    "@digital-alchemy/type-writer": "npm:^24.8.1"
     "@types/figlet": "npm:^1.5.8"
     "@types/jest": "npm:^29.5.12"
     "@types/js-yaml": "npm:^4.0.9"
@@ -1045,11 +1025,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@digital-alchemy/synapse@npm:^24.8.1":
-  version: 24.8.1
-  resolution: "@digital-alchemy/synapse@npm:24.8.1"
+"@digital-alchemy/synapse@npm:^24.8.2":
+  version: 24.8.2
+  resolution: "@digital-alchemy/synapse@npm:24.8.2"
   dependencies:
-    "@digital-alchemy/fastify-extension": "npm:*"
+    "@digital-alchemy/fastify-extension": "npm:^24.8.1"
     better-sqlite3: "npm:^11.0.0"
     dayjs: "npm:^1.11.11"
     node-ssdp: "npm:^4.0.1"
@@ -1059,13 +1039,13 @@ __metadata:
   dependenciesMeta:
     "@digital-alchemy/fastify-extension":
       optional: true
-  checksum: 10/df0957537cdede94bca0bdeb0d83de4e856ed5205958302ace41baf55f0fa5e3fb442d95a7fe433b6fde7e73ede97cb3350463603890e19ff422614980c6b2b1
+  checksum: 10/6762a695b8280ec0ebd5b40160c283acf1dbf903eb4497795e840e6a494847fcbf5d2a3e2695ee3ff2462a61771c6f72ead55ffd19db2946ef021ac9f5dc297b
   languageName: node
   linkType: hard
 
-"@digital-alchemy/type-writer@npm:^24.7.2":
-  version: 24.7.2
-  resolution: "@digital-alchemy/type-writer@npm:24.7.2"
+"@digital-alchemy/type-writer@npm:^24.8.1":
+  version: 24.8.1
+  resolution: "@digital-alchemy/type-writer@npm:24.8.1"
   dependencies:
     js-yaml: "npm:^4.1.0"
     quicktype: "npm:^23.0.170"
@@ -1076,7 +1056,7 @@ __metadata:
     "@digital-alchemy/hass": "*"
   bin:
     type-writer: dist/main.js
-  checksum: 10/618ec45c39596d509529f9c21a0479d3c4d42b3de2f31f6f771cfe2d7f42841626af103c177de55a7e1c566ec6c2b20b8d7df57414a6d3cba784767973bf831b
+  checksum: 10/d86b4b90f02e966cb1ed7fc4f74eff92a38824aec885c88528eb7bc2430cbc31cc4af8a3dbeb6960fa50087b3898fe8b77ea348e96eb21d8c648b0054a97b1fd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 📬 Changes

- `hass.idBy.area` now considers entities that are registered to devices in the area

#62 

## 🗒️ Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme and [docs](https://docs.digital-alchemy.app/) (updated or not needed)
- [x] Tests (added, updated or not needed)
