### PR TITLE
Add ownKeys & has operators to proxies

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -24,6 +24,7 @@ words:
   - rtsp
   - sonarjs
   - mbit
+  - datetime
   - kbit
   - ssdp
   - systype

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@digital-alchemy/hass",
   "repository": "https://github.com/Digital-Alchemy-TS/hass",
   "homepage": "https://docs.digital-alchemy.app",
-  "version": "24.8.3",
+  "version": "24.9.1",
   "description": "Typescript APIs for Home Assistant. Includes rest & websocket bindings",
   "scripts": {
     "build": "rm -rf dist/; tsc",
@@ -63,7 +63,7 @@
     "@cspell/eslint-plugin": "^8.8.4",
     "@digital-alchemy/core": "^24.8.4",
     "@digital-alchemy/synapse": "^24.8.2",
-    "@digital-alchemy/type-writer": "^24.8.1",
+    "@digital-alchemy/type-writer": "^24.8.2",
     "@types/figlet": "^1.5.8",
     "@types/jest": "^29.5.12",
     "@types/js-yaml": "^4.0.9",

--- a/src/extensions/call-proxy.extension.ts
+++ b/src/extensions/call-proxy.extension.ts
@@ -125,6 +125,7 @@ export function CallProxy({
         return Object.keys(rawProxy);
       },
       set() {
+        // lol, no
         return false;
       },
     });

--- a/src/extensions/call-proxy.extension.ts
+++ b/src/extensions/call-proxy.extension.ts
@@ -118,6 +118,15 @@ export function CallProxy({
         }
         return rawProxy[domain];
       },
+      has(_, property: string) {
+        return property in rawProxy;
+      },
+      ownKeys() {
+        return Object.keys(rawProxy);
+      },
+      set() {
+        return false;
+      },
     });
   }
 

--- a/src/extensions/config.extension.ts
+++ b/src/extensions/config.extension.ts
@@ -20,9 +20,12 @@ import {
 const MAX_ATTEMPTS = 50;
 const FAILED = 1;
 
+export const SERVICE_LIST_UPDATED = "SERVICE_LIST_UPDATED";
+
 export function Configure({
   logger,
   lifecycle,
+  event,
   hass,
   config,
   internal,
@@ -96,8 +99,10 @@ export function Configure({
       );
       await sleep(config.hass.RETRY_INTERVAL * SECOND);
       await loadServiceList(recursion + INCREMENT);
+    } else {
+      event.emit(SERVICE_LIST_UPDATED, services);
+      checkedServices = new Map();
     }
-    checkedServices = new Map();
   }
   let checkedServices = new Map<string, boolean>();
 

--- a/src/extensions/reference.extension.ts
+++ b/src/extensions/reference.extension.ts
@@ -85,6 +85,27 @@ export function ReferenceExtension({
       const thing = hass.entity.getCurrentState(
         entity_id,
       ) as ByIdProxy<ENTITY_ID>;
+
+      function keys() {
+        const entityDomain = domain(entity_id);
+        return [
+          "attributes",
+          "entity_id",
+          "history",
+          "last",
+          "nextState",
+          "once",
+          "onUpdate",
+          "previous",
+          "removeAllListeners",
+          "state",
+          "waitForState",
+          ...hass.configure
+            .getServices()
+            .filter(({ domain }) => domain === entityDomain)
+            .flatMap(i => Object.keys(i.services)),
+        ];
+      }
       ENTITY_PROXIES.set(
         entity_id,
         // just because you can't do generics properly....
@@ -217,6 +238,12 @@ export function ReferenceExtension({
               };
             }
             return proxyGetLogic(entity_id, property);
+          },
+          has(_, property: string) {
+            return keys().includes(property);
+          },
+          ownKeys() {
+            return keys();
           },
           set(
             _,

--- a/src/extensions/reference.extension.ts
+++ b/src/extensions/reference.extension.ts
@@ -1,14 +1,17 @@
 import {
+  DOWN,
   is,
   NONE,
   sleep,
   TAnyFunction,
   TServiceParams,
+  UP,
 } from "@digital-alchemy/core";
 import dayjs, { Dayjs } from "dayjs";
 import { Get } from "type-fest";
 import { isNumeric } from "validator";
 
+import { SERVICE_LIST_UPDATED } from "..";
 import {
   TAreaId,
   TDeviceId,
@@ -82,9 +85,10 @@ export function ReferenceExtension({
   ): ByIdProxy<ENTITY_ID> {
     const entity_domain = domain(entity_id) as ALL_SERVICE_DOMAINS;
     if (!ENTITY_PROXIES.has(entity_id)) {
-      const thing = hass.entity.getCurrentState(
+      const { ...thing } = hass.entity.getCurrentState(
         entity_id,
       ) as ByIdProxy<ENTITY_ID>;
+      let loaded = false;
 
       function keys() {
         const entityDomain = domain(entity_id);
@@ -103,9 +107,25 @@ export function ReferenceExtension({
           ...hass.configure
             .getServices()
             .filter(({ domain }) => domain === entityDomain)
-            .flatMap(i => Object.keys(i.services)),
+            .flatMap(i => Object.keys(i.services))
+            .sort((a, b) => (a > b ? UP : DOWN)),
         ];
       }
+      function appendKeys(force = false) {
+        if (loaded && !force) {
+          return;
+        }
+        // Not gonna build types for this, and ts-expect-error fails in jest
+        // This is a weird hack for an obscure feature, so sue me
+        //
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        keys().forEach(i => (thing[i] ??= () => {}));
+        if (!is.empty(hass.configure.getServices())) {
+          loaded = true;
+        }
+      }
+      event.on(SERVICE_LIST_UPDATED, () => appendKeys(true));
       ENTITY_PROXIES.set(
         entity_id,
         // just because you can't do generics properly....
@@ -240,10 +260,12 @@ export function ReferenceExtension({
             return proxyGetLogic(entity_id, property);
           },
           has(_, property: string) {
-            return keys().includes(property);
+            appendKeys();
+            return property in thing;
           },
           ownKeys() {
-            return keys();
+            appendKeys();
+            return Object.keys(thing);
           },
           set(
             _,

--- a/src/helpers/fetch/service-list.ts
+++ b/src/helpers/fetch/service-list.ts
@@ -60,5 +60,5 @@ export interface ResponseOptional {
 
 export interface HassServiceDTO {
   domain: ALL_DOMAINS;
-  services: Record<string, ServiceListField>;
+  services: Record<string /* via .name */, ServiceListField>;
 }

--- a/src/testing/ref-by.spec.ts
+++ b/src/testing/ref-by.spec.ts
@@ -9,7 +9,7 @@ import dayjs from "dayjs";
 import { ANY_ENTITY, ENTITY_STATE } from "../helpers";
 import { CreateTestingApplication, SILENT_BOOT } from "../mock_assistant";
 
-describe("ID By", () => {
+describe("References", () => {
   let application: ApplicationDefinition<
     ServiceMap,
     OptionalModuleConfiguration
@@ -23,301 +23,394 @@ describe("ID By", () => {
     jest.restoreAllMocks();
   });
 
-  describe("refBy.id", () => {
-    it("can grab references by id", async () => {
-      expect.assertions(2);
-      application = CreateTestingApplication({
-        Test({ lifecycle, hass }: TServiceParams) {
-          lifecycle.onReady(() => {
-            const sensor = hass.refBy.id("sensor.magic");
-            expect(sensor).toBeDefined();
-            expect(sensor.state).toBe("unavailable");
-          });
-        },
+  describe("loading", function () {
+    describe("refBy.id", () => {
+      it("can grab references by id", async () => {
+        expect.assertions(2);
+        application = CreateTestingApplication({
+          Test({ lifecycle, hass }: TServiceParams) {
+            lifecycle.onReady(() => {
+              const sensor = hass.refBy.id("sensor.magic");
+              expect(sensor).toBeDefined();
+              expect(sensor.state).toBe("unavailable");
+            });
+          },
+        });
+        await application.bootstrap(
+          SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
+        );
       });
-      await application.bootstrap(
-        SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
-      );
     });
 
-    it("references have attributes", async () => {
-      expect.assertions(1);
-      application = CreateTestingApplication({
-        Test({ lifecycle, hass }: TServiceParams) {
-          lifecycle.onReady(() => {
-            const sensor = hass.refBy.id("sensor.magic");
-            expect(sensor.attributes).toEqual(
-              expect.objectContaining({ friendly_name: "magic" }),
-            );
-          });
-        },
+    describe("domain", () => {
+      it("load references by domain", async () => {
+        expect.assertions(1);
+        application = CreateTestingApplication({
+          Test({ lifecycle, hass }: TServiceParams) {
+            lifecycle.onReady(() => {
+              const sensor = hass.refBy.domain("sensor");
+              expect(sensor.length).toBe(8);
+            });
+          },
+        });
+        await application.bootstrap(
+          SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
+        );
       });
-      await application.bootstrap(
-        SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
-      );
     });
 
-    it("references do not return random attributes", async () => {
-      expect.assertions(1);
-      application = CreateTestingApplication({
-        Test({ lifecycle, hass }: TServiceParams) {
-          lifecycle.onReady(() => {
-            const sensor = hass.refBy.id("sensor.magic");
-            // @ts-expect-error it's the test
-            expect(sensor.foo).toBeUndefined();
-          });
-        },
+    describe("unique_id", () => {
+      it("load references by unique_id", async () => {
+        expect.assertions(1);
+        application = CreateTestingApplication({
+          Test({ lifecycle, hass }: TServiceParams) {
+            lifecycle.onReady(() => {
+              const sensor = hass.refBy.unique_id(
+                "e1806fdc93296bbd5ab42967003cd38729ff9ba6cfeefc3e15a03ad01ac894fe",
+              );
+              expect(sensor.entity_id).toBe("sensor.magic");
+            });
+          },
+        });
+        await application.bootstrap(
+          SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
+        );
       });
-      await application.bootstrap(
-        SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
-      );
     });
 
-    it("references provide last_* as dayjs", async () => {
-      expect.assertions(3);
-      application = CreateTestingApplication({
-        Test({ lifecycle, hass }: TServiceParams) {
-          lifecycle.onReady(() => {
-            const sensor = hass.refBy.id("sensor.magic");
-            expect(sensor.last_changed instanceof dayjs).toBe(true);
-            expect(sensor.last_reported instanceof dayjs).toBe(true);
-            expect(sensor.last_updated instanceof dayjs).toBe(true);
-          });
-        },
+    describe("label", () => {
+      it("load references by label", async () => {
+        expect.assertions(1);
+        application = CreateTestingApplication({
+          Test({ lifecycle, hass }: TServiceParams) {
+            lifecycle.onReady(() => {
+              const list = hass.refBy.label("synapse");
+              expect(list.length).toBe(7);
+            });
+          },
+        });
+        await application.bootstrap(
+          SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
+        );
       });
-      await application.bootstrap(
-        SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
-      );
+
+      it("load references by label limiting by domain", async () => {
+        expect.assertions(1);
+        application = CreateTestingApplication({
+          Test({ lifecycle, hass }: TServiceParams) {
+            lifecycle.onReady(() => {
+              const list = hass.refBy.label("synapse", "light");
+              expect(list.length).toBe(0);
+            });
+          },
+        });
+        await application.bootstrap(
+          SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
+        );
+      });
     });
 
-    it("passes through history calls", async () => {
-      expect.assertions(2);
-      application = CreateTestingApplication({
-        Test({ lifecycle, hass }: TServiceParams) {
-          lifecycle.onReady(async () => {
-            const result = [] as ENTITY_STATE<ANY_ENTITY>[];
-            const spy = jest
-              .spyOn(hass.fetch, "fetchEntityHistory")
-              .mockImplementation(async () => result);
-            const from = new Date();
-            const to = new Date();
-            const entity_id = "sensor.magic";
-
-            const entity = hass.refBy.id(entity_id);
-            const out = await entity.history(from, to);
-            expect(spy).toHaveBeenCalledWith(entity_id, from, to);
-            expect(out).toBe(result);
-          });
-        },
+    describe("area", () => {
+      it("load references by area", async () => {
+        expect.assertions(2);
+        application = CreateTestingApplication({
+          Test({ lifecycle, hass }: TServiceParams) {
+            lifecycle.onReady(() => {
+              const bedroom = hass.refBy.area("bedroom");
+              const kitchen = hass.refBy.area("kitchen");
+              expect(bedroom.length).toBe(2);
+              expect(kitchen.length).toBe(1);
+            });
+          },
+        });
+        await application.bootstrap(
+          SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
+        );
       });
-      await application.bootstrap(
-        SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
-      );
-    });
-  });
 
-  describe("domain", () => {
-    it("load references by domain", async () => {
-      expect.assertions(1);
-      application = CreateTestingApplication({
-        Test({ lifecycle, hass }: TServiceParams) {
-          lifecycle.onReady(() => {
-            const sensor = hass.refBy.domain("sensor");
-            expect(sensor.length).toBe(8);
-          });
-        },
+      it("load references by area limiting by domain", async () => {
+        expect.assertions(2);
+        application = CreateTestingApplication({
+          Test({ lifecycle, hass }: TServiceParams) {
+            lifecycle.onReady(() => {
+              const bedroom = hass.refBy.area("bedroom", "light");
+              const kitchen = hass.refBy.area("kitchen", "light");
+              expect(bedroom.length).toBe(1);
+              expect(kitchen.length).toBe(0);
+            });
+          },
+        });
+        await application.bootstrap(
+          SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
+        );
       });
-      await application.bootstrap(
-        SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
-      );
-    });
-  });
-
-  describe("unique_id", () => {
-    it("load references by unique_id", async () => {
-      expect.assertions(1);
-      application = CreateTestingApplication({
-        Test({ lifecycle, hass }: TServiceParams) {
-          lifecycle.onReady(() => {
-            const sensor = hass.refBy.unique_id(
-              "e1806fdc93296bbd5ab42967003cd38729ff9ba6cfeefc3e15a03ad01ac894fe",
-            );
-            expect(sensor.entity_id).toBe("sensor.magic");
-          });
-        },
-      });
-      await application.bootstrap(
-        SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
-      );
-    });
-  });
-
-  describe("label", () => {
-    it("load references by label", async () => {
-      expect.assertions(1);
-      application = CreateTestingApplication({
-        Test({ lifecycle, hass }: TServiceParams) {
-          lifecycle.onReady(() => {
-            const list = hass.refBy.label("synapse");
-            expect(list.length).toBe(7);
-          });
-        },
-      });
-      await application.bootstrap(
-        SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
-      );
     });
 
-    it("load references by label limiting by domain", async () => {
-      expect.assertions(1);
-      application = CreateTestingApplication({
-        Test({ lifecycle, hass }: TServiceParams) {
-          lifecycle.onReady(() => {
-            const list = hass.refBy.label("synapse", "light");
-            expect(list.length).toBe(0);
-          });
-        },
+    describe("device", () => {
+      it("load references by device", async () => {
+        expect.assertions(1);
+        application = CreateTestingApplication({
+          Test({ lifecycle, hass }: TServiceParams) {
+            lifecycle.onReady(() => {
+              const synapse = hass.refBy.device(
+                "308e39cf50a9fc6c30b4110724ed1f2e",
+              );
+              expect(synapse.length).toBe(9);
+            });
+          },
+        });
+        await application.bootstrap(
+          SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
+        );
       });
-      await application.bootstrap(
-        SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
-      );
-    });
-  });
 
-  describe("area", () => {
-    it("load references by area", async () => {
-      expect.assertions(2);
-      application = CreateTestingApplication({
-        Test({ lifecycle, hass }: TServiceParams) {
-          lifecycle.onReady(() => {
-            const bedroom = hass.refBy.area("bedroom");
-            const kitchen = hass.refBy.area("kitchen");
-            expect(bedroom.length).toBe(2);
-            expect(kitchen.length).toBe(1);
-          });
-        },
+      it("load references by device limiting by domain", async () => {
+        expect.assertions(1);
+        application = CreateTestingApplication({
+          Test({ lifecycle, hass }: TServiceParams) {
+            lifecycle.onReady(() => {
+              const synapse = hass.refBy.device(
+                "308e39cf50a9fc6c30b4110724ed1f2e",
+                "light",
+              );
+              expect(synapse.length).toBe(0);
+            });
+          },
+        });
+        await application.bootstrap(
+          SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
+        );
       });
-      await application.bootstrap(
-        SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
-      );
-    });
-
-    it("load references by area limiting by domain", async () => {
-      expect.assertions(2);
-      application = CreateTestingApplication({
-        Test({ lifecycle, hass }: TServiceParams) {
-          lifecycle.onReady(() => {
-            const bedroom = hass.refBy.area("bedroom", "light");
-            const kitchen = hass.refBy.area("kitchen", "light");
-            expect(bedroom.length).toBe(1);
-            expect(kitchen.length).toBe(0);
-          });
-        },
-      });
-      await application.bootstrap(
-        SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
-      );
-    });
-  });
-
-  describe("device", () => {
-    it("load references by device", async () => {
-      expect.assertions(1);
-      application = CreateTestingApplication({
-        Test({ lifecycle, hass }: TServiceParams) {
-          lifecycle.onReady(() => {
-            const synapse = hass.refBy.device(
-              "308e39cf50a9fc6c30b4110724ed1f2e",
-            );
-            expect(synapse.length).toBe(9);
-          });
-        },
-      });
-      await application.bootstrap(
-        SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
-      );
     });
 
-    it("load references by device limiting by domain", async () => {
-      expect.assertions(1);
-      application = CreateTestingApplication({
-        Test({ lifecycle, hass }: TServiceParams) {
-          lifecycle.onReady(() => {
-            const synapse = hass.refBy.device(
-              "308e39cf50a9fc6c30b4110724ed1f2e",
-              "light",
-            );
-            expect(synapse.length).toBe(0);
-          });
-        },
+    describe("platform", () => {
+      it("load references by platform", async () => {
+        expect.assertions(1);
+        application = CreateTestingApplication({
+          Test({ lifecycle, hass }: TServiceParams) {
+            lifecycle.onReady(() => {
+              const synapse = hass.refBy.platform("synapse");
+              expect(synapse.length).toBe(7);
+            });
+          },
+        });
+        await application.bootstrap(
+          SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
+        );
       });
-      await application.bootstrap(
-        SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
-      );
+
+      it("load references by platform limiting by domain", async () => {
+        expect.assertions(1);
+        application = CreateTestingApplication({
+          Test({ lifecycle, hass }: TServiceParams) {
+            lifecycle.onReady(() => {
+              const synapse = hass.refBy.platform("synapse", "light");
+              expect(synapse.length).toBe(0);
+            });
+          },
+        });
+        await application.bootstrap(
+          SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
+        );
+      });
+    });
+
+    describe("floor", () => {
+      it("load references by floor", async () => {
+        expect.assertions(1);
+        application = CreateTestingApplication({
+          Test({ lifecycle, hass }: TServiceParams) {
+            lifecycle.onReady(() => {
+              const synapse = hass.refBy.floor("downstairs");
+              expect(synapse.length).toBe(3);
+            });
+          },
+        });
+        await application.bootstrap(
+          SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
+        );
+      });
+
+      it("load references by floor limiting by domain", async () => {
+        expect.assertions(1);
+        application = CreateTestingApplication({
+          Test({ lifecycle, hass }: TServiceParams) {
+            lifecycle.onReady(() => {
+              const synapse = hass.refBy.floor("downstairs", "light");
+              expect(synapse.length).toBe(0);
+            });
+          },
+        });
+        await application.bootstrap(
+          SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
+        );
+      });
     });
   });
 
-  describe("platform", () => {
-    it("load references by platform", async () => {
-      expect.assertions(1);
-      application = CreateTestingApplication({
-        Test({ lifecycle, hass }: TServiceParams) {
-          lifecycle.onReady(() => {
-            const synapse = hass.refBy.platform("synapse");
-            expect(synapse.length).toBe(7);
-          });
-        },
+  describe("functionality", () => {
+    describe("operators", () => {
+      it("has", async () => {
+        expect.assertions(15);
+        application = CreateTestingApplication({
+          Test({ lifecycle, hass }: TServiceParams) {
+            lifecycle.onReady(() => {
+              const entity = hass.refBy.id("switch.bedroom_lamp");
+              // always there stuff
+              expect("does not exist" in entity).toBe(false);
+              [
+                "attributes",
+                "entity_id",
+                "history",
+                "last",
+                "nextState",
+                "once",
+                "onUpdate",
+                "previous",
+                "removeAllListeners",
+                "state",
+                "waitForState",
+              ].forEach(property => expect(property in entity).toBe(true));
+              // service calls exist too
+              ["toggle", "turn_off", "turn_on"].forEach(method =>
+                expect(method in entity).toBe(true),
+              );
+            });
+          },
+        });
+        await application.bootstrap(
+          SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
+        );
       });
-      await application.bootstrap(
-        SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
-      );
+
+      it("ownKeys", async () => {
+        expect.assertions(1);
+        application = CreateTestingApplication({
+          Test({ lifecycle, hass }: TServiceParams) {
+            lifecycle.onReady(() => {
+              const entity = hass.refBy.id("switch.bedroom_lamp");
+              const keys = Object.keys(entity);
+              // note: each section sorted alphabetically
+              expect(keys).toEqual([
+                // hard coded
+                "entity_id",
+                "state",
+                "attributes",
+                "last_changed",
+                "last_reported",
+                "last_updated",
+                "context",
+                "history",
+                "last",
+                "nextState",
+                "once",
+                "onUpdate",
+                "previous",
+                "removeAllListeners",
+                "waitForState",
+                // services
+                "toggle",
+                "turn_off",
+                "turn_on",
+              ]);
+            });
+          },
+        });
+        await application.bootstrap(
+          SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
+        );
+      });
+      describe("set", () => {
+        it("state", () => {
+          // stub
+        });
+        it("attributes", () => {
+          // stub
+        });
+        it("everything else", () => {
+          // stub
+        });
+      });
     });
 
-    it("load references by platform limiting by domain", async () => {
-      expect.assertions(1);
-      application = CreateTestingApplication({
-        Test({ lifecycle, hass }: TServiceParams) {
-          lifecycle.onReady(() => {
-            const synapse = hass.refBy.platform("synapse", "light");
-            expect(synapse.length).toBe(0);
-          });
-        },
+    describe("get", () => {
+      it("references have attributes", async () => {
+        expect.assertions(2);
+        application = CreateTestingApplication({
+          Test({ lifecycle, hass }: TServiceParams) {
+            lifecycle.onReady(() => {
+              const sensor = hass.refBy.id("sensor.magic");
+              expect("attributes" in sensor).toBe(true);
+              expect(sensor.attributes).toEqual(
+                expect.objectContaining({ friendly_name: "magic" }),
+              );
+            });
+          },
+        });
+        await application.bootstrap(
+          SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
+        );
       });
-      await application.bootstrap(
-        SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
-      );
-    });
-  });
 
-  describe("floor", () => {
-    it("load references by floor", async () => {
-      expect.assertions(1);
-      application = CreateTestingApplication({
-        Test({ lifecycle, hass }: TServiceParams) {
-          lifecycle.onReady(() => {
-            const synapse = hass.refBy.floor("downstairs");
-            expect(synapse.length).toBe(3);
-          });
-        },
+      // mental note: legacy test
+      // better covered by the ownKeys & has operator tests now
+      it("references do not return random attributes", async () => {
+        expect.assertions(1);
+        application = CreateTestingApplication({
+          Test({ lifecycle, hass }: TServiceParams) {
+            lifecycle.onReady(() => {
+              const sensor = hass.refBy.id("sensor.magic");
+              // @ts-expect-error it's the test
+              expect(sensor.foo).toBeUndefined();
+            });
+          },
+        });
+        await application.bootstrap(
+          SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
+        );
       });
-      await application.bootstrap(
-        SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
-      );
-    });
 
-    it("load references by floor limiting by domain", async () => {
-      expect.assertions(1);
-      application = CreateTestingApplication({
-        Test({ lifecycle, hass }: TServiceParams) {
-          lifecycle.onReady(() => {
-            const synapse = hass.refBy.floor("downstairs", "light");
-            expect(synapse.length).toBe(0);
-          });
-        },
+      it("references provide last_* as dayjs", async () => {
+        expect.assertions(3);
+        application = CreateTestingApplication({
+          Test({ lifecycle, hass }: TServiceParams) {
+            lifecycle.onReady(() => {
+              const sensor = hass.refBy.id("sensor.magic");
+              expect(sensor.last_changed instanceof dayjs).toBe(true);
+              expect(sensor.last_reported instanceof dayjs).toBe(true);
+              expect(sensor.last_updated instanceof dayjs).toBe(true);
+            });
+          },
+        });
+        await application.bootstrap(
+          SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
+        );
       });
-      await application.bootstrap(
-        SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
-      );
+
+      it("passes through history calls", async () => {
+        expect.assertions(2);
+        application = CreateTestingApplication({
+          Test({ lifecycle, hass }: TServiceParams) {
+            lifecycle.onReady(async () => {
+              const result = [] as ENTITY_STATE<ANY_ENTITY>[];
+              const spy = jest
+                .spyOn(hass.fetch, "fetchEntityHistory")
+                .mockImplementation(async () => result);
+              const from = new Date();
+              const to = new Date();
+              const entity_id = "sensor.magic";
+
+              const entity = hass.refBy.id(entity_id);
+              const out = await entity.history(from, to);
+              expect(spy).toHaveBeenCalledWith(entity_id, from, to);
+              expect(out).toBe(result);
+            });
+          },
+        });
+        await application.bootstrap(
+          SILENT_BOOT({ hass: { MOCK_SOCKET: true } }, true),
+        );
+      });
     });
   });
 });

--- a/src/testing/workflow.spec.ts
+++ b/src/testing/workflow.spec.ts
@@ -140,4 +140,69 @@ describe("Workflows", () => {
       );
     });
   });
+
+  describe("Call", () => {
+    const EXPECTED_KEYS = [
+      "persistent_notification",
+      "homeassistant",
+      "system_log",
+      "logger",
+      "recorder",
+      "person",
+      "frontend",
+      "cloud",
+      "ffmpeg",
+      "tts",
+      "scene",
+      "timer",
+      "input_number",
+      "conversation",
+      "input_select",
+      "zone",
+      "input_button",
+      "script",
+      "automation",
+      "logbook",
+      "input_boolean",
+      "button",
+      "switch",
+      "input_datetime",
+      "backup",
+      "shopping_list",
+      "counter",
+      "schedule",
+      "input_text",
+      "synapse",
+      "todo",
+      "notify",
+      "calendar",
+    ];
+    it("does not allow set", async () => {
+      expect.assertions(1);
+      await runner(undefined, async ({ hass }) => {
+        try {
+          // @ts-expect-error testing
+          hass.call.button = {};
+        } catch (error) {
+          expect(error).toBeDefined();
+        }
+      });
+    });
+
+    it("provides keys via ownKeys", async () => {
+      expect.assertions(1);
+      await runner(undefined, async ({ hass }) => {
+        const keys = Object.keys(hass.call);
+        expect(keys).toEqual(EXPECTED_KEYS);
+      });
+    });
+
+    it("does has correctly", async () => {
+      expect.assertions(34);
+      await runner(undefined, async ({ hass }) => {
+        EXPECTED_KEYS.forEach(i => expect(i in hass.call).toBe(true));
+        expect("unknown_property" in hass.call).toBe(false);
+      });
+    });
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -981,7 +981,7 @@ __metadata:
     "@cspell/eslint-plugin": "npm:^8.8.4"
     "@digital-alchemy/core": "npm:^24.8.4"
     "@digital-alchemy/synapse": "npm:^24.8.2"
-    "@digital-alchemy/type-writer": "npm:^24.8.1"
+    "@digital-alchemy/type-writer": "npm:^24.8.2"
     "@types/figlet": "npm:^1.5.8"
     "@types/jest": "npm:^29.5.12"
     "@types/js-yaml": "npm:^4.0.9"
@@ -1043,9 +1043,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@digital-alchemy/type-writer@npm:^24.8.1":
-  version: 24.8.1
-  resolution: "@digital-alchemy/type-writer@npm:24.8.1"
+"@digital-alchemy/type-writer@npm:^24.8.2":
+  version: 24.8.2
+  resolution: "@digital-alchemy/type-writer@npm:24.8.2"
   dependencies:
     js-yaml: "npm:^4.1.0"
     quicktype: "npm:^23.0.170"
@@ -1056,7 +1056,7 @@ __metadata:
     "@digital-alchemy/hass": "*"
   bin:
     type-writer: dist/main.js
-  checksum: 10/d86b4b90f02e966cb1ed7fc4f74eff92a38824aec885c88528eb7bc2430cbc31cc4af8a3dbeb6960fa50087b3898fe8b77ea348e96eb21d8c648b0054a97b1fd
+  checksum: 10/2c49d92ac34b979e566ee7cb777e4a51c30a7733874696f792f6a5c7f5015ced6ce391e376943ee7dbb9351dd7fd3a8472af49c94751c86b1d4387b0cb2cda87
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 📬 Changes

- add `ownKeys`, `has`, `apply`, `set` as appropriate (and sometimes inappropriate)

## 🗒️ Checklist

<!-- please check all items and add your own -->

- [x] Read the contribution [guide](../CONTRIBUTING.md) and accept the
  [code](../CODE_OF_CONDUCT.md) of conduct
- [x] Readme and [docs](https://docs.digital-alchemy.app/) (updated or not needed)
- [x] Tests (added, updated or not needed)
