### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,6 @@
 name: Publish
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Digital-Alchemy-TS/hass/security/code-scanning/3](https://github.com/Digital-Alchemy-TS/hass/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimal required permissions for the `GITHUB_TOKEN`. Since the workflow only checks out code, installs dependencies, runs tests, and publishes to npm (using an npm token, not the `GITHUB_TOKEN`), it does not require any write permissions to the repository. Therefore, setting `permissions: contents: read` at the workflow level is sufficient and follows the principle of least privilege. This change should be made at the top level of the workflow file, just below the `name` field and before the `on` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
